### PR TITLE
Use Go 1.7 in Drone and golang-version-check.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,4 +1,4 @@
-image: clever/drone-go:1.6
+image: clever/drone-go:1.7
 notify:
   email:
     recipients:


### PR DESCRIPTION
You were assigned as the most active recent contributor to this repo.
Please reassign and share the joy of Go 1.7 if needed, or ask in #golang
if you have any questions.
