### PR TITLE
Translate path fix

### DIFF
--- a/s3driver.go
+++ b/s3driver.go
@@ -215,6 +215,11 @@ func (d S3Driver) PutFile(path string, r io.Reader) error {
 	return err
 }
 
+func (d S3Driver) RealPath(path string) string {
+	result, _ := TranslatePath("/", d.homePath, path)
+	return "/" + result
+}
+
 // translatePath takes in a S3 root prefix, a home directory, and either an absolute or relative path to append, and returns a cleaned and validated path.
 // It will resolve things like '..' while disallowing the prefix to be escaped.
 // It also preserves a single trailing slash if one is present, so it can be used on both directories and files.

--- a/s3driver_test.go
+++ b/s3driver_test.go
@@ -12,34 +12,34 @@ import (
 )
 
 func TestTranslatePathSimple(t *testing.T) {
-	path, err := translatePath("sftp/test_user", "/file")
+	path, err := TranslatePath("", "sftp/test_user", "/file")
 	if err != nil || path != "sftp/test_user/file" {
 		t.FailNow()
 	}
 
-	path, err = translatePath("sftp/test_user", "/dir/")
+	path, err = TranslatePath("", "sftp/test_user", "/dir/")
 	if err != nil || path != "sftp/test_user/dir/" {
 		t.FailNow()
 	}
 
-	path, err = translatePath("sftp/test_user", "/dir/file")
+	path, err = TranslatePath("", "sftp/test_user", "/dir/file")
 	if err != nil || path != "sftp/test_user/dir/file" {
 		t.FailNow()
 	}
 
-	path, err = translatePath("sftp/test_user", "/dir/../some_other_file")
+	path, err = TranslatePath("", "sftp/test_user", "/dir/../some_other_file")
 	if err != nil || path != "sftp/test_user/some_other_file" {
 		t.FailNow()
 	}
 }
 
 func TestTranslatePathEscaping(t *testing.T) {
-	path, err := translatePath("sftp/test_user", "/dir/../../some_escape_attempt")
+	path, err := TranslatePath("sftp", "/test_user", "/dir/../../some_escape_attempt")
 	if err != nil || path != "sftp/test_user/some_escape_attempt" {
 		t.FailNow()
 	}
 
-	path, err = translatePath("sftp/test_user", "///dir/./../../../another_escape_attempt")
+	path, err = TranslatePath("sftp", "sftp/test_user", "///dir/./../../../another_escape_attempt")
 	if err != nil || path != "sftp/test_user/another_escape_attempt" {
 		t.FailNow()
 	}

--- a/s3driver_test.go
+++ b/s3driver_test.go
@@ -11,37 +11,56 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestTranslatePathSimple(t *testing.T) {
-	path, err := TranslatePath("", "sftp/test_user", "/file")
-	if err != nil || path != "sftp/test_user/file" {
-		t.FailNow()
+func TestTranslatePath(t *testing.T) {
+	testCases := []struct {
+		prefix, desc, home, path, result string
+	}{
+		{
+			desc:   "trivial path",
+			home:   "sftp/test_user",
+			path:   "file",
+			result: "sftp/test_user/file",
+		},
+		{
+			desc:   "trivial directory",
+			home:   "sftp/test_user",
+			path:   "dir/",
+			result: "sftp/test_user/dir/",
+		},
+		{
+			desc:   "nested path",
+			home:   "sftp/test_user",
+			path:   "dir/file",
+			result: "sftp/test_user/dir/file",
+		},
+		{
+			desc:   "path w/ ..",
+			home:   "sftp/test_user",
+			path:   "dir/../some_other_file",
+			result: "sftp/test_user/some_other_file",
+		},
+		{
+			desc:   "handle escaping attempt",
+			prefix: "sftp",
+			home:   "/test_user",
+			path:   "dir/../../some_escape_attempt",
+			result: "sftp/test_user/some_escape_attempt",
+		},
+		{
+			desc:   "convoluted escape attempt",
+			prefix: "sftp",
+			home:   "/test_user",
+			path:   "///dir/./../../../another_escape_attempt",
+			result: "sftp", // ends up w/ the base path
+		},
 	}
 
-	path, err = TranslatePath("", "sftp/test_user", "/dir/")
-	if err != nil || path != "sftp/test_user/dir/" {
-		t.FailNow()
-	}
-
-	path, err = TranslatePath("", "sftp/test_user", "/dir/file")
-	if err != nil || path != "sftp/test_user/dir/file" {
-		t.FailNow()
-	}
-
-	path, err = TranslatePath("", "sftp/test_user", "/dir/../some_other_file")
-	if err != nil || path != "sftp/test_user/some_other_file" {
-		t.FailNow()
-	}
-}
-
-func TestTranslatePathEscaping(t *testing.T) {
-	path, err := TranslatePath("sftp", "/test_user", "/dir/../../some_escape_attempt")
-	if err != nil || path != "sftp/test_user/some_escape_attempt" {
-		t.FailNow()
-	}
-
-	path, err = TranslatePath("sftp", "sftp/test_user", "///dir/./../../../another_escape_attempt")
-	if err != nil || path != "sftp/test_user/another_escape_attempt" {
-		t.FailNow()
+	for _, spec := range testCases {
+		t.Run(spec.desc, func(t *testing.T) {
+			path, err := TranslatePath(spec.prefix, spec.home, spec.path)
+			assert.NoError(t, err)
+			assert.Equal(t, spec.result, path)
+		})
 	}
 }
 
@@ -178,7 +197,7 @@ func TestRename(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestMakeDir(t *testing.T) {
+func TestRelativeMakeDir(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockS3API := NewMockS3API(mockCtrl)
@@ -186,6 +205,26 @@ func TestMakeDir(t *testing.T) {
 	mockS3API.EXPECT().PutObject(&s3.PutObjectInput{
 		Bucket:               aws.String("bucket"),
 		Key:                  aws.String("home/new_dir/"),
+		ServerSideEncryption: aws.String("AES256"),
+		Body:                 bytes.NewReader([]byte{}),
+	}).Return(nil, nil)
+
+	driver := &S3Driver{
+		s3:       mockS3API,
+		bucket:   "bucket",
+		homePath: "home",
+	}
+	assert.NoError(t, driver.MakeDir("new_dir"))
+}
+
+func TestAbsoluteMakeDir(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockS3API := NewMockS3API(mockCtrl)
+
+	mockS3API.EXPECT().PutObject(&s3.PutObjectInput{
+		Bucket:               aws.String("bucket"),
+		Key:                  aws.String("new_dir/"),
 		ServerSideEncryption: aws.String("AES256"),
 		Body:                 bytes.NewReader([]byte{}),
 	}).Return(nil, nil)

--- a/server.go
+++ b/server.go
@@ -29,7 +29,7 @@ type ServerDriver interface {
 	MakeDir(path string) error
 	GetFile(path string) (io.ReadCloser, error)
 	PutFile(path string, reader io.Reader) error
-	TranslatePath(root, homedir, path string) (string, error)
+	RealPath(path string) string
 }
 
 // Server is an SSH File Transfer Protocol (sftp) server.
@@ -301,7 +301,7 @@ func handlePacket(s *Server, p interface{}) error {
 	case *sshFxpReadlinkPacket:
 		return s.sendError(p, fmt.Errorf("Not supported"))
 	case *sshFxpRealpathPacket:
-		f := s.driver.TranslatePath("", "", p.Path)
+		f := s.driver.RealPath(p.Path)
 		return s.sendPacket(sshFxpNamePacket{
 			ID: p.ID,
 			NameAttrs: []sshFxpNameAttr{{

--- a/testfiledriver.go
+++ b/testfiledriver.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 )
 
 type TestFileDriver struct{}
@@ -43,4 +44,8 @@ func (d TestFileDriver) PutFile(path string, r io.Reader) error {
 		return err
 	}
 	return ioutil.WriteFile(path, bytes, 0755)
+}
+
+func (d TestFileDriver) TranslatePath(root, homedir, path string) (string, error) {
+	return filepath.Clean("/" + path)
 }

--- a/testfiledriver.go
+++ b/testfiledriver.go
@@ -46,6 +46,6 @@ func (d TestFileDriver) PutFile(path string, r io.Reader) error {
 	return ioutil.WriteFile(path, bytes, 0755)
 }
 
-func (d TestFileDriver) TranslatePath(root, homedir, path string) (string, error) {
+func (d TestFileDriver) RealPath(path string) string {
 	return filepath.Clean("/" + path)
 }


### PR DESCRIPTION
This alters the behavior of `TranslatePath` to keep in mind both a credentials limited prefix as well as a home directory when translating SFTP input values to full S3 paths.