### PR TITLE
don't try to close files that do not exist

### DIFF
--- a/server.go
+++ b/server.go
@@ -408,8 +408,11 @@ func (svr *Server) Serve() error {
 
 	// close any still-open files
 	for handle, file := range svr.openFiles {
-		fmt.Fprintf(svr.debugStream, "sftp server file with handle %q left open: %v\n", handle, file.TempHandle.Name())
-		file.TempHandle.Close()
+		if !file.IsDir {
+			fmt.Fprintf(svr.debugStream, "sftp server file with handle %q left open: %v\n",
+				handle, file.TempHandle.Name())
+			file.TempHandle.Close()
+		}
 	}
 	return err // error from recvPacket
 }


### PR DESCRIPTION
Prevent the errors seen here: https://production--haproxy-logs.int.clever.com/_plugin/kibana/#/discover?_a=(columns:!(rawlog),filters:!((meta:(disabled:!f,index:%5Blogs-%5DYYYY.MM.DD,key:via,negate:!t,value:process-metrics),query:(match:(via:(query:process-metrics,type:phrase)))),(meta:(disabled:!f,index:%5Blogs-%5DYYYY.MM.DD,key:error,negate:!t,value:'ssh:%20disconnect,%20reason%2011:%20'),query:(match:(error:(query:'ssh:%20disconnect,%20reason%2011:%20',type:phrase)))),(meta:(disabled:!f,index:%5Blogs-%5DYYYY.MM.DD,key:title,negate:!t,value:login-success),query:(match:(title:(query:login-success,type:phrase))))),index:%5Blogs-%5DYYYY.MM.DD,interval:auto,query:(query_string:(analyze_wildcard:!t,lowercase_expanded_terms:!f,query:'container_app:clever-sftp%20AND%20NOT%20_exists_:title%20AND%20NOT%20%22file%20does%20not%20exist%22')),sort:!(Timestamp,desc))&_g=(refreshInterval:(display:Off,pause:!f,section:0,value:0),time:(from:now-48h,mode:relative,to:now))