### PR TITLE
SOC-1668 fix rmdir

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 machine:
   post:
   - cd $HOME && git clone --depth 1 -v git@github.com:clever/ci-scripts.git && cd ci-scripts && git show --oneline -s
-  - $HOME/ci-scripts/circleci/golang-install 1.8
+  - $HOME/ci-scripts/circleci/golang-install 1.10
   services:
   - docker
 checkout:

--- a/client_integration_linux_test.go
+++ b/client_integration_linux_test.go
@@ -29,14 +29,14 @@ func TestClientStatVFS(t *testing.T) {
 
 	// check some stats
 	if vfs.Frsize != uint64(s.Frsize) {
-		t.Fatal("fr_size does not match, expected: %v, got: %v", s.Frsize, vfs.Frsize)
+		t.Fatalf("fr_size does not match, expected: %v, got: %v", s.Frsize, vfs.Frsize)
 	}
 
 	if vfs.Bsize != uint64(s.Bsize) {
-		t.Fatal("f_bsize does not match, expected: %v, got: %v", s.Bsize, vfs.Bsize)
+		t.Fatalf("f_bsize does not match, expected: %v, got: %v", s.Bsize, vfs.Bsize)
 	}
 
 	if vfs.Namemax != uint64(s.Namelen) {
-		t.Fatal("f_namemax does not match, expected: %v, got: %v", s.Namelen, vfs.Namemax)
+		t.Fatalf("f_namemax does not match, expected: %v, got: %v", s.Namelen, vfs.Namemax)
 	}
 }

--- a/s3driver.go
+++ b/s3driver.go
@@ -115,9 +115,16 @@ func (d S3Driver) DeleteDir(path string) error {
 	if err != nil {
 		return err
 	}
+
+	// s3 DeleteObject needs a trailing slash for directories
+	directoryPath := translatedPath
+	if !strings.HasSuffix(translatedPath, "/") {
+		directoryPath = translatedPath + "/"
+	}
+
 	_, err = d.s3.DeleteObject(&s3.DeleteObjectInput{
 		Bucket: aws.String(d.bucket),
-		Key:    aws.String(translatedPath),
+		Key:    aws.String(directoryPath),
 	})
 	return err
 }

--- a/s3driver_test.go
+++ b/s3driver_test.go
@@ -145,7 +145,27 @@ func TestDeleteDir(t *testing.T) {
 		bucket:   "bucket",
 		homePath: "home",
 	}
-	err := driver.DeleteDir("../../dir/")
+	err := driver.DeleteFile("../../dir/")
+
+	assert.NoError(t, err)
+}
+
+func TestDeleteDirImplicitSlash(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockS3API := NewMockS3API(mockCtrl)
+
+	mockS3API.EXPECT().DeleteObject(&s3.DeleteObjectInput{
+		Bucket: aws.String("bucket"),
+		Key:    aws.String("home/dir/"),
+	}).Return(nil, nil)
+
+	driver := &S3Driver{
+		s3:       mockS3API,
+		bucket:   "bucket",
+		homePath: "home",
+	}
+	err := driver.DeleteDir("../../dir")
 
 	assert.NoError(t, err)
 }
@@ -165,7 +185,7 @@ func TestDeleteFile(t *testing.T) {
 		bucket:   "bucket",
 		homePath: "home",
 	}
-	err := driver.DeleteDir("../../dir/file")
+	err := driver.DeleteFile("../../dir/file")
 
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
to match typical sftp behavior
s3 API requires trailing slash for directories

verified locally