### PR TITLE
Ddoc 24 add download logging

### DIFF
--- a/s3driver.go
+++ b/s3driver.go
@@ -211,12 +211,14 @@ func (d S3Driver) GetFile(path string) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	d.lg.InfoD("s3Driver-get-file-success", meta{
-		"district_id":     d.bucket,
-		"method":          "GET",
-		"path":            localPath,
-		"file_bytes_size": obj.ContentLength,
-	})
+	if d.lg != nil {
+		d.lg.InfoD("s3Driver-get-file-success", meta{
+			"district_id":     d.bucket,
+			"method":          "GET",
+			"path":            localPath,
+			"file_bytes_size": obj.ContentLength,
+		})
+	}
 	return obj.Body, nil
 }
 
@@ -245,12 +247,14 @@ func (d S3Driver) PutFile(path string, r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	d.lg.InfoD("s3Driver-put-file-success", meta{
-		"district_id":     d.bucket,
-		"method":          "PUT",
-		"path":            localPath,
-		"file_bytes_size": input.ContentLength,
-	})
+	if d.lg != nil {
+		d.lg.InfoD("s3Driver-put-file-success", meta{
+			"district_id":     d.bucket,
+			"method":          "PUT",
+			"path":            localPath,
+			"file_bytes_size": input.ContentLength,
+		})
+	}
 	return nil
 }
 

--- a/s3driver.go
+++ b/s3driver.go
@@ -13,6 +13,15 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"gopkg.in/Clever/kayvee-go.v6/logger"
+)
+
+const (
+	serviceName = "sftp"
+)
+
+var (
+	lg = logger.New(serviceName)
 )
 
 type S3 interface {
@@ -210,6 +219,12 @@ func (d S3Driver) GetFile(path string) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
+	lg.InfoD("s3Driver-get-file-success", logger.M{
+		"district_id":     d.bucket,
+		"method":          "GET",
+		"path":            localPath,
+		"file_bytes_size": obj.ContentLength,
+	})
 	return obj.Body, nil
 }
 
@@ -235,7 +250,16 @@ func (d S3Driver) PutFile(path string, r io.Reader) error {
 		input.SSEKMSKeyId = aws.String(*d.kmsKeyID)
 	}
 	_, err = d.s3.PutObject(input)
-	return err
+	if err != nil {
+		return err
+	}
+	lg.InfoD("s3Driver-put-file-success", logger.M{
+		"district_id":     d.bucket,
+		"method":          "PUT",
+		"path":            localPath,
+		"file_bytes_size": input.ContentLength,
+	})
+	return nil
 }
 
 func (d S3Driver) RealPath(path string) string {

--- a/s3driver_test.go
+++ b/s3driver_test.go
@@ -2,6 +2,7 @@ package sftp
 
 import (
 	"bytes"
+	"log"
 	"testing"
 	"time"
 
@@ -10,6 +11,20 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )
+
+// mockLogger and its methods are placeholders for a passed in Logger.
+// It matches a subset of the Clever/kayvee-go library.
+type mockLogger struct{}
+
+func (mockLogger mockLogger) InfoD(title string, meta map[string]interface{}) {
+	log.Println("Title:", title)
+	log.Println("Meta:", meta)
+}
+
+func (mockLogger mockLogger) ErrorD(title string, meta map[string]interface{}) {
+	log.Println("Title:", title)
+	log.Println("Meta:", meta)
+}
 
 func TestTranslatePath(t *testing.T) {
 	testCases := []struct {
@@ -275,6 +290,7 @@ func TestGetFile(t *testing.T) {
 		s3:       mockS3API,
 		bucket:   "bucket",
 		homePath: "home",
+		lg:       mockLogger{},
 	}
 	_, err := driver.GetFile("../../dir/file")
 
@@ -297,6 +313,7 @@ func TestPutFile(t *testing.T) {
 		s3:       mockS3API,
 		bucket:   "bucket",
 		homePath: "home",
+		lg:       mockLogger{},
 	}
 	err := driver.PutFile("../../dir/file", bytes.NewReader([]byte{1, 2, 3}))
 
@@ -322,6 +339,7 @@ func TestPutFileWithKmsKeyID(t *testing.T) {
 		bucket:   "bucket",
 		homePath: "home",
 		kmsKeyID: &kmsKeyID,
+		lg:       mockLogger{},
 	}
 	err := driver.PutFile("../../dir/file", bytes.NewReader([]byte{1, 2, 3}))
 

--- a/s3driver_test.go
+++ b/s3driver_test.go
@@ -2,7 +2,6 @@ package sftp
 
 import (
 	"bytes"
-	"log"
 	"testing"
 	"time"
 
@@ -11,20 +10,6 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )
-
-// mockLogger and its methods are placeholders for a passed in Logger.
-// It matches a subset of the Clever/kayvee-go library.
-type mockLogger struct{}
-
-func (mockLogger mockLogger) InfoD(title string, meta map[string]interface{}) {
-	log.Println("Title:", title)
-	log.Println("Meta:", meta)
-}
-
-func (mockLogger mockLogger) ErrorD(title string, meta map[string]interface{}) {
-	log.Println("Title:", title)
-	log.Println("Meta:", meta)
-}
 
 func TestTranslatePath(t *testing.T) {
 	testCases := []struct {
@@ -290,7 +275,6 @@ func TestGetFile(t *testing.T) {
 		s3:       mockS3API,
 		bucket:   "bucket",
 		homePath: "home",
-		lg:       mockLogger{},
 	}
 	_, err := driver.GetFile("../../dir/file")
 
@@ -313,7 +297,6 @@ func TestPutFile(t *testing.T) {
 		s3:       mockS3API,
 		bucket:   "bucket",
 		homePath: "home",
-		lg:       mockLogger{},
 	}
 	err := driver.PutFile("../../dir/file", bytes.NewReader([]byte{1, 2, 3}))
 
@@ -339,7 +322,6 @@ func TestPutFileWithKmsKeyID(t *testing.T) {
 		bucket:   "bucket",
 		homePath: "home",
 		kmsKeyID: &kmsKeyID,
-		lg:       mockLogger{},
 	}
 	err := driver.PutFile("../../dir/file", bytes.NewReader([]byte{1, 2, 3}))
 


### PR DESCRIPTION
[JIRA](https://clever.atlassian.net/browse/DDOC-24)

This PR adds an extra param to our S3 driver allowing for logging (primarily to be used in conjunction with the Clever/kayvee-go library). We initially add logging for the `GetFile` and `PutFile` methods. 

Build error is expected since there is no `.circleci config` for this repo. However, ran `go test -v` and all tests passed. This should be able to be merged in regardless according to [this thread](https://clever.slack.com/archives/C08G6CNMN/p1645140930119439)

Testing

Not sure how to actually test the logs but I plan on making the changes in `clever-sftp` where this library is used and will confirm whether the logs show from there before pulling this updated version of the `sftp` library

Current testing plan:

- [x] Ran all tests and all passed
- [x] Test `clever-sftp` locally with the updated changes to the `sftp` library and confirm whether the logs actually render. (Logs weren't rendering correctly but pushed a couple changes in order to do so)
