### PR TITLE
notify CI failure

### DIFF
--- a/.github/workflows/notify-ci-status.yml
+++ b/.github/workflows/notify-ci-status.yml
@@ -1,0 +1,20 @@
+name: Notify CI status
+
+on:
+  check_suite:
+    types: [completed]
+  status:
+
+jobs:
+  call-workflow:
+    if: >-
+      (github.event.branches[0].name == github.event.repository.default_branch &&
+        (github.event.state == 'error' || github.event.state == 'failure')) ||
+      (github.event.check_suite.head_branch == github.event.repository.default_branch &&
+        github.event.check_suite.conclusion != 'success')
+    uses: Clever/ci-scripts/.github/workflows/reusable-notify-ci-status.yml@master
+    secrets:
+      CIRCLE_CI_INTEGRATIONS_URL: ${{ secrets.CIRCLE_CI_INTEGRATIONS_URL }}
+      CIRCLE_CI_INTEGRATIONS_USERNAME: ${{ secrets.CIRCLE_CI_INTEGRATIONS_USERNAME }}
+      CIRCLE_CI_INTEGRATIONS_PASSWORD: ${{ secrets.CIRCLE_CI_INTEGRATIONS_PASSWORD }}
+      SLACK_BOT_TOKEN: ${{ secrets.DAPPLE_BOT_TOKEN }}


### PR DESCRIPTION
# Jira
https://clever.atlassian.net/browse/INFRANG-6435

## Overview
PR created via Microplane

This PR enables/fixes slack notifications via Dapple bot when CI fails on master, sent to the commit author, to ensure that eng action can be taken to ensure master doesn't remain in a failed state. This prevents issues such as a subsequent deploy deploying more new code than intended because it picks up a previous failed build's code.

If you have questions, please ask here or in #oncall-infra.

Feel free to merge this PR upon reviewing or simply ignore. If it is ignored, it will be merged by infra eventually

## Testing
This github action has been tested in our `do-nothing` repo and test details can be found in https://github.com/Clever/ci-scripts/pull/140
