### PR TITLE
add logging

### DIFF
--- a/managedserver.go
+++ b/managedserver.go
@@ -37,6 +37,10 @@ type LoginRequest struct {
 	RemoteAddr net.Addr
 }
 
+type subsystemRequest struct {
+	Name string
+}
+
 // ManagedServer is our term for the SFTP server.
 type ManagedServer struct {
 	driverGenerator func(LoginRequest) ServerDriver
@@ -133,7 +137,7 @@ func (m ManagedServer) Start(port int, rawPrivateKeys [][]byte, ciphers, macs []
 				config.AddHostKey(privateKey)
 			}
 
-			_, newChan, requestChan, err := ssh.NewServerConn(conn, config)
+			sshConn, newChan, requestChan, err := ssh.NewServerConn(conn, config)
 			if err != nil {
 				if err != io.EOF {
 					m.errorAndAlert("handshake-failure", meta{"error": err.Error()})
@@ -162,6 +166,7 @@ func (m ManagedServer) Start(port int, rawPrivateKeys [][]byte, ciphers, macs []
 				go func(in <-chan *ssh.Request) {
 					for req := range in {
 						ok := false
+						subsystemName := ""
 						switch req.Type {
 						case "subsystem":
 							if len(req.Payload) >= 4 {
@@ -170,7 +175,18 @@ func (m ManagedServer) Start(port int, rawPrivateKeys [][]byte, ciphers, macs []
 									ok = true
 								}
 							}
+							subsystemReq := &subsystemRequest{}
+							if err := ssh.Unmarshal(req.Payload, subsystemReq); err == nil {
+								subsystemName = subsystemReq.Name
+							}
 						}
+						m.lg.InfoD("session-request", meta{
+							"request-type": req.Type,
+							"accepted":     ok,
+							"subsystem":    subsystemName,
+							"username":     sshConn.User(),
+							"client-ip":    sshConn.RemoteAddr().String(),
+						})
 						req.Reply(ok, nil)
 					}
 				}(requests)


### PR DESCRIPTION
## JIRA
https://clever.atlassian.net/browse/DIOC-1670

## Overview
Adding in additional logging to see if I can determine if the subsystem / sftp checks are failing here for the Rapid Identity client. 

## Testing
N/A this isn't deployed, only a package library. Will test once I pull into clever-sftp

Note this repo has been failing CI for a while now due to unrelated infrastructure debt. We have opted to not fix that and just merge it and pull it into clever-sftp. The long term plan is to move on to an AWS hosted sftp server. 

## Rollout
💯 
Will merge this then pull it into clever-sftp and merge that. 

## Clever Coding Standards Agreement

- [x] Author and Review Statement, "We agree this code adheres to our [Clever Global Coding Standards](https://app.getguru.com/folders/ibabX5oT/Engineering-Standards-Best-Practices?activeCard=a8a444f4-9149-4ec7-a0fd-8ba42519d93e) and other applicable [Coding Standards](https://app.getguru.com/folders/ibabX5oT/Engineering-Standards-Best-Practices)"