### PR TITLE
fix stat error

### DIFF
--- a/server.go
+++ b/server.go
@@ -629,6 +629,8 @@ func statusFromError(p id, err error) sshFxpStatusPacket {
 		ret.StatusError.msg = err.Error()
 		if err == io.EOF {
 			ret.StatusError.Code = ssh_FX_EOF
+		} else if err == os.ErrNotExist {
+			ret.StatusError.Code = ssh_FX_NO_SUCH_FILE
 		} else if errno, ok := err.(syscall.Errno); ok {
 			ret.StatusError.Code = translateErrno(errno)
 		} else if pathError, ok := err.(*os.PathError); ok {


### PR DESCRIPTION


## JIRA
https://clever.atlassian.net/browse/DIOC-1695

## Overview
LAUSD is seeing a general failure error when they attempt to use the AWS SFTP Connector feature to do an sftp transfer.

The bug: When AWS Transfer Family SFTP Connector does a STAT on a non-existent destination file, the server returns SSH_FX_FAILURE (code 4, "General failure") instead of the correct SSH_FX_NO_SUCH_FILE (code 2). AWS interprets SSH_FX_FAILURE as a hard server error and aborts immediately, never even attempting the write.

Why: In statusFromError, os.ErrNotExist is not a syscall.Errno and not an *os.PathError, so it falls through to the default ssh_FX_FAILURE. The SFTP protocol spec requires STAT to return SSH_FX_NO_SUCH_FILE for missing files.

Why other clients work: Standard sftp clients (OpenSSH, etc.) don't STAT before writing — they just OPEN with SSH_FXF_WRITE|SSH_FXF_CREAT|SSH_FXF_TRUNC directly. AWS Transfer Family's connector does a pre-flight STAT and is strict about the response code.

The fix is a one-liner in statusFromError in the sftp dependency

## Testing
Will test this locally with clever-sftp

## Rollout
💯 

## Rollback
💯 

## Clever Coding Standards Agreement

- [x] Author and Review Statement, "We agree this code adheres to our [Clever Global Coding Standards](https://app.getguru.com/folders/ibabX5oT/Engineering-Standards-Best-Practices?activeCard=a8a444f4-9149-4ec7-a0fd-8ba42519d93e) and other applicable [Coding Standards](https://app.getguru.com/folders/ibabX5oT/Engineering-Standards-Best-Practices)"